### PR TITLE
Fix Docker build failure by installing git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY . /app
 
 RUN pip install --upgrade pip
+RUN apt-get update && apt-get install -y git
 RUN pip install -r requirements.txt
 RUN pip install git+https://github.com/serpapi/serpapi-python.git
 


### PR DESCRIPTION
## Summary
- install `git` in Dockerfile before installing requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `docker build . -t ai-search-test` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f3c5890d08326918d770dcbab6b1f