### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ A Streamlit app that lets you:
 ## Notes
 
 - Only text is extracted from images and office documents (no formatting, formulas, or embedded objects).
-- Cross-check is as good as the OpenAI model and web search allow.
+- Cross-check is as good as the OpenAI model and web search allows.


### PR DESCRIPTION
## Summary
- fix grammar typo in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f4fb1e26c832685b604e038f21d83