### PR TITLE
Fix supported file formats markdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,7 +105,7 @@ if uploaded:
 
 st.markdown("""
 ---
-**Supports**: PDF, DOCX, XLSX, PPTX, JPG, PNG  
+**Supports**: PDF, DOCX, XLSX, PPTX, JPG, JPEG, PNG  
 - Uses OCR for images  
 - LLM-powered summarization & fact cross-check  
 - Requires [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) for image support  


### PR DESCRIPTION
## Summary
- update the list of supported image formats in the Streamlit markdown

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_683f4fbd770c8326a53c61c64eb73eae