### PR TITLE
Fix serpapi ImportError by adding package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pandas
 pdfplumber
 pillow
 pytesseract
+google-search-results


### PR DESCRIPTION
## Summary
- install serpapi's official client via `google-search-results` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f523048f083269126f5b055e775b1