### PR TITLE
Fix serpapi import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY . /app
 RUN pip install --upgrade pip
 RUN apt-get update && apt-get install -y git
 RUN pip install -r requirements.txt
-RUN pip install git+https://github.com/serpapi/serpapi-python.git
 
 EXPOSE 8000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pandas
 pdfplumber
 pillow
 pytesseract
-google-search-results
+serpapi

--- a/utils/serp_openai.py
+++ b/utils/serp_openai.py
@@ -1,16 +1,15 @@
-from serpapi import GoogleSearch
+import serpapi
 import openai
 import requests
 from bs4 import BeautifulSoup
 
 def fetch_and_summarize(query, openai_key, serpapi_key):
+    search_client = serpapi.Client(api_key=serpapi_key)
     params = {
         "q": query,
-        "api_key": serpapi_key,
         "engine": "google"
     }
-    search = GoogleSearch(params)
-    results = search.get_dict()
+    results = search_client.search(params)
     if "organic_results" in results and results["organic_results"]:
         url = results["organic_results"][0]["link"]
         # Fetch and extract web content
@@ -22,8 +21,8 @@ def fetch_and_summarize(query, openai_key, serpapi_key):
         except Exception as e:
             web_content = f"Unable to fetch web content: {e}\nURL: {url}"
         # Summarize with OpenAI
-        client = openai.OpenAI(api_key=openai_key)
-        completion = client.chat.completions.create(
+        openai_client = openai.OpenAI(api_key=openai_key)
+        completion = openai_client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
                 {"role": "system", "content": "Summarize the following web content in a factual, neutral, concise way."},


### PR DESCRIPTION
## Summary
- switch serpapi integration to use new Client interface
- update Python requirements to use `serpapi` package
- remove extra install line from Dockerfile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5780dbd08326b84b0d149490c6b5