### PR TITLE
Add GET routes for API info

### DIFF
--- a/api/research.py
+++ b/api/research.py
@@ -6,6 +6,19 @@ from utils.serp_openai import fetch_and_summarize
 
 app = FastAPI()
 
+@app.get("/")
+async def root_info():
+    """Return basic usage information."""
+    return {
+        "message": "Use POST /research with JSON {'text': 'your content'} to summarize"
+    }
+
+@app.get("/research")
+async def research_get_info():
+    """Provide instructions for the research endpoint."""
+    return {
+        "detail": "Send a POST request with a JSON body {'text': '<your text>'}"}
+
 @app.post("/research")
 async def research_file(request: Request):
     data = await request.json()


### PR DESCRIPTION
## Summary
- allow GET / and GET /research to return usage information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5a140eec832683e52b835bf43df0