### PR TITLE
Add summarizer and browser unit tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+
+# Provide dummy environment variables for tests
+os.environ.setdefault('OPENAI_API_KEY', 'test-key')
+os.environ.setdefault('SERPAPI_KEY', 'test-key')
+
+# Stub openai module if not installed
+if 'openai' not in sys.modules:
+    openai_module = types.ModuleType('openai')
+
+    class DummyChatCompletions:
+        def __init__(self):
+            self.create = lambda *args, **kwargs: None
+
+    class DummyChat:
+        def __init__(self):
+            self.completions = DummyChatCompletions()
+
+    class DummyOpenAI:
+        def __init__(self, api_key=None):
+            self.chat = DummyChat()
+
+    openai_module.OpenAI = DummyOpenAI
+    sys.modules['openai'] = openai_module
+
+# Stub trafilatura if missing
+if 'trafilatura' not in sys.modules:
+    trafilatura_module = types.ModuleType('trafilatura')
+    def _extract(html, include_comments=False, include_tables=False):
+        try:
+            from bs4 import BeautifulSoup
+            soup = BeautifulSoup(html, 'html.parser')
+            if soup.body:
+                return soup.body.get_text(separator='\n')
+            return soup.get_text(separator='\n')
+        except Exception:
+            return None
+    trafilatura_module.extract = _extract
+    sys.modules['trafilatura'] = trafilatura_module
+
+# Minimal stub for playwright.async_api to satisfy imports
+if 'playwright.async_api' not in sys.modules:
+    playwright_module = types.ModuleType('playwright')
+    async_api_module = types.ModuleType('playwright.async_api')
+    async_api_module.async_playwright = lambda: None
+    playwright_module.async_api = async_api_module
+    sys.modules['playwright'] = playwright_module
+    sys.modules['playwright.async_api'] = async_api_module

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,97 @@
+import sys, os
+import types
+import asyncio
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import browser
+
+class DummyLink:
+    def __init__(self, page):
+        self.page = page
+    async def click(self):
+        self.page.clicked = True
+
+class DummyPage:
+    def __init__(self, final_html, unusual=False, raise_exc=False, no_links=False):
+        self.final_html = final_html
+        self.unusual = unusual
+        self.raise_exc = raise_exc
+        self.no_links = no_links
+        self.goto_url = None
+        self.clicked = False
+
+    async def set_extra_http_headers(self, headers):
+        pass
+
+    async def goto(self, url, timeout=60000):
+        self.goto_url = url
+
+    async def content(self):
+        if not self.clicked:
+            if self.unusual:
+                return "detected unusual traffic"
+            return "<html>results</html>"
+        return self.final_html
+
+    async def wait_for_selector(self, selector, timeout=10000):
+        if self.raise_exc:
+            raise Exception("selector not found")
+
+    async def query_selector_all(self, selector):
+        if self.no_links:
+            return []
+        return [DummyLink(self)]
+
+    async def wait_for_load_state(self, state):
+        pass
+
+class DummyBrowser:
+    def __init__(self, page):
+        self.page = page
+    async def new_page(self, user_agent):
+        return self.page
+    async def close(self):
+        pass
+
+class DummyPlaywright:
+    def __init__(self, page):
+        self.page = page
+    @property
+    def chromium(self):
+        return self
+    async def launch(self, headless=True):
+        return DummyBrowser(self.page)
+
+class DummyContext:
+    def __init__(self, page):
+        self.playwright = DummyPlaywright(page)
+    async def __aenter__(self):
+        return self.playwright
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+def make_async_playwright(page):
+    def _async_playwright():
+        return DummyContext(page)
+    return _async_playwright
+
+def test_google_search_success(monkeypatch):
+    page = DummyPage('<final>content</final>')
+    monkeypatch.setattr(browser, 'async_playwright', make_async_playwright(page))
+    result = asyncio.run(browser.google_search_and_scrape('foo'))
+    assert page.goto_url.endswith('foo')
+    assert result == '<final>content</final>'
+
+def test_google_search_blocked(monkeypatch):
+    page = DummyPage('<final>', unusual=True)
+    monkeypatch.setattr(browser, 'async_playwright', make_async_playwright(page))
+    result = asyncio.run(browser.google_search_and_scrape('foo'))
+    assert result is None
+
+def test_google_search_error(monkeypatch):
+    page = DummyPage('<final>', raise_exc=True)
+    monkeypatch.setattr(browser, 'async_playwright', make_async_playwright(page))
+    result = asyncio.run(browser.google_search_and_scrape('foo'))
+    assert result is None

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,38 @@
+import types
+import sys, os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import summarizer
+
+class DummyResponse:
+    def __init__(self, content):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+
+
+def test_gpt_generate_query(monkeypatch):
+    def fake_create(*args, **kwargs):
+        return DummyResponse('search query')
+    monkeypatch.setattr(summarizer.client.chat.completions, 'create', fake_create)
+    assert summarizer.gpt_generate_query('anything') == 'search query'
+
+
+def test_gpt_summarize(monkeypatch):
+    def fake_create(*args, **kwargs):
+        return DummyResponse('summary text')
+    monkeypatch.setattr(summarizer.client.chat.completions, 'create', fake_create)
+    assert summarizer.gpt_summarize('text to summarize') == 'summary text'
+
+
+def test_gpt_summarize_no_text(monkeypatch):
+    calls = []
+
+    def fake_create(*args, **kwargs):
+        calls.append(1)
+        return DummyResponse('should not be used')
+
+    monkeypatch.setattr(summarizer.client.chat.completions, 'create', fake_create)
+    result = summarizer.gpt_summarize('')
+    assert result == 'No article text available.'
+    assert not calls


### PR DESCRIPTION
## Summary
- provide dummy environment variables and stub modules in `tests/__init__.py`
- mock OpenAI client in `test_summarizer` to test query and summarization helpers
- mock Playwright in `test_browser` to test search scraping logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f3270944832695dbb1c0057aa3f5