### PR TITLE
Install Playwright and tesseract in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 COPY . /app
 
 RUN pip install --upgrade pip
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git tesseract-ocr
 RUN pip install -r requirements.txt
+RUN playwright install --with-deps
 
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ A Streamlit app that lets you:
 
 1. Clone this repo.
 2. `pip install -r requirements.txt`
-3. `playwright install`
+3. `playwright install --with-deps`
 4. Install [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) for image reading (Linux: `sudo apt install tesseract-ocr`).
 5. Set your OpenAI API key:  
    - On Linux/Mac: `export OPENAI_API_KEY=sk-...`
    - On Windows: `set OPENAI_API_KEY=sk-...`
 6. Run: `streamlit run app.py`
+   - The provided Dockerfile installs Playwright and Tesseract automatically.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- update Dockerfile to install `tesseract-ocr`
- install Playwright browsers with deps during build
- document updated setup instructions

## Testing
- `pytest -q`
- `playwright install --with-deps` *(fails: Download failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6846f315e25c8326ac68856705f326e9