### PR TITLE
Add env variable checks for API keys

### DIFF
--- a/api/research.py
+++ b/api/research.py
@@ -25,9 +25,20 @@ async def research_file(request: Request):
     text = data.get("text", "")
     if not text:
         return JSONResponse({"summary": "No text provided.", "source_url": ""}, status_code=400)
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    serp_key = os.environ.get("SERPAPI_KEY")
+    if not openai_key or not serp_key:
+        missing = []
+        if not openai_key:
+            missing.append("OPENAI_API_KEY")
+        if not serp_key:
+            missing.append("SERPAPI_KEY")
+        detail = f"Missing required environment variables: {', '.join(missing)}"
+        return JSONResponse({"detail": detail}, status_code=500)
+
     result = fetch_and_summarize(
         text,
-        openai_key=os.environ["OPENAI_API_KEY"],
-        serpapi_key=os.environ["SERPAPI_KEY"]
+        openai_key=openai_key,
+        serpapi_key=serp_key,
     )
     return JSONResponse(result)

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,0 +1,15 @@
+import sys
+import os
+import importlib
+from fastapi.testclient import TestClient
+
+
+def test_research_returns_500_when_keys_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SERPAPI_KEY", raising=False)
+    import api.research as research
+    client = TestClient(research.app)
+    response = client.post("/research", json={"text": "test"})
+    assert response.status_code == 500
+    assert "OPENAI_API_KEY" in response.json()["detail"]
+

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,14 @@
+import importlib
+import os
+import sys
+import pytest
+
+# Remove module from cache to force reimport
+
+def test_summarizer_raises_without_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    sys.modules.pop("utils.summarizer", None)
+    with pytest.raises(RuntimeError):
+        import utils.summarizer  # noqa: F401
+
+

--- a/utils/summarizer.py
+++ b/utils/summarizer.py
@@ -1,7 +1,14 @@
 import openai
 import os
 
-client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Validate that the OpenAI API key is available before creating the client.
+_openai_key = os.environ.get("OPENAI_API_KEY")
+if not _openai_key:
+    raise RuntimeError(
+        "OPENAI_API_KEY environment variable must be set to use the summarizer"
+    )
+
+client = openai.OpenAI(api_key=_openai_key)
 
 def gpt_generate_query(prompt):
     messages = [


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` when loading summarizer
- validate `SERPAPI_KEY` and `OPENAI_API_KEY` in research endpoint
- add tests for missing API keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f31f75908326a90931f96ece049a